### PR TITLE
[CO-235] Limit memory of systemd plugin.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN buildDeps='build-essential \
     cd /tmp && \
     unzip "fluent-bit-$FLB_VERSION-dev.zip" && \
     cd "fluent-bit-$FLB_VERSION/build/" && \
-    cmake -DFLB_JEMALLOC=on -DFLB_BUFFERING=On -DCMAKE_INSTALL_PREFIX=/fluent-bit/ .. && \
+    cmake -DFLB_JEMALLOC=On -DFLB_BUFFERING=On -DCMAKE_INSTALL_PREFIX=/fluent-bit/ .. && \
     make && \
     make install && \
     cd / && \

--- a/fluent-bit.conf
+++ b/fluent-bit.conf
@@ -7,6 +7,7 @@
     Name            systemd
     Tag             host.*
     Path            /var/log/journal
+    Mem_Buf_Limit 5MB
 
 [INPUT]
     Name          tail


### PR DESCRIPTION
This is required to prevent fluent-bit from using more memory than allocated by the pod spec.